### PR TITLE
chore(deps): upgrade toolchains

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,20 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "github.com/docker/*"
+          - "github.com/moby/*"
+      common:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,12 +5,16 @@ on:
     branches: [ "main" ]
     tags: [ "v*" ]
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
 
 jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,18 +14,17 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: [1.24.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.platform}}
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 
-    - name: Set up Go ${{matrix.go-version}}
+    - name: Set up Go
       uses: actions/setup-go@v5
       id: go
       with:
-        go-version: ${{matrix.go-version}}
+        go-version-file: go.mod
 
     - name: Install Go Task Tool
       uses: arduino/setup-task@v2

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/wuxler/ruasec
 
-go 1.22
-toolchain go1.24.1
+go 1.24
 
 require (
 	github.com/benbjohnson/clock v1.3.5


### PR DESCRIPTION
# Overview

This PR updates Go version from `1.22` to `1.24` and `golangci-lint` version from `1.56.2` to `1.64.7`.

# Description

This PR includes the following changes:

1. Update Go version to 1.24 in `go.mod` file.
2. Switch `go-version` to `go-version-file` in GitHub Actions workflow [actions/setup-go@v5](https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file)
3. Bump `golangci-lint` to 1.64.7 that support Go 1.24.
4. Modify `.golangci-lint.yaml` file for golangci-lint 1.64.7.
